### PR TITLE
Mac indexer now uses absolute paths

### DIFF
--- a/IndalekoMacLocalIndexer.py
+++ b/IndalekoMacLocalIndexer.py
@@ -173,6 +173,7 @@ def main():
                         help='Logging level to use (lower number = more logging)')
 
     args = parser.parse_args()
+    args.path=os.path.abspath(args.path)
     indexer = IndalekoMacLocalIndexer(timestamp=timestamp,
                                           path=args.path,
                                           machine_config=machine_config)


### PR DESCRIPTION
- The indexer in Mac didn't use absolute paths. Now, it uses absolute paths.
- Previously, we had to import the vertices and relationships manually using arangoimport cli. These files were created as a result of ingestion.  Now, the ingester itself imports both vertices and edges. The files are still being created.
- Because of the unique constraints, the reset flag is used for dropping collections before ingestion. The default behaviour is not to drop and has to be provided by the user

closes #40
closes #38
